### PR TITLE
Improve closing trade retrieval

### DIFF
--- a/modules/brokerHandler.js
+++ b/modules/brokerHandler.js
@@ -157,21 +157,22 @@ async function getClosingDealInfo(positionId) {
       const toDate = new Date();
       const fromDate = new Date(toDate.getTime() - 48 * 60 * 60 * 1000); // 48 jam yang lalu
 
-      const response = await apiClient.get(`/history_deals_get?from_date=${fromDate.toISOString()}&to_date=${toDate.toISOString()}`);
-      const allDeals = response.data;
+      const url = `/history_deals_get?from_date=${fromDate.toISOString()}&to_date=${toDate.toISOString()}&position=${positionId}`;
+      const response = await apiClient.get(url);
+      const deals = response.data;
 
-      if (!allDeals || !Array.isArray(allDeals) || allDeals.length === 0) {
-          log.info(`[BROKER HANDLER] Tidak ada history deals yang ditemukan dalam 48 jam terakhir.`);
+      if (!deals || !Array.isArray(deals) || deals.length === 0) {
+          log.info(`[BROKER HANDLER] Tidak ada history deals untuk posisi ${positionId}.`);
           return null;
       }
-      
-      const closingDeal = allDeals.find(deal => deal.position_id === positionId && deal.entry === 1);
+
+      const closingDeal = deals.find(deal => deal.entry === 1);
 
       if (closingDeal) {
           log.info(`[BROKER HANDLER] SUKSES! Closing deal yang valid ditemukan untuk position ${positionId}:`, closingDeal);
           return closingDeal;
       } else {
-          log.warn(`[BROKER HANDLER] PERINGATAN: Tidak ada closing deal yang cocok untuk Position ID ${positionId} di riwayat terbaru.`);
+          log.warn(`[BROKER HANDLER] PERINGATAN: Tidak ada closing deal yang cocok untuk Position ID ${positionId}.`);
           return null;
       }
 

--- a/modules/monitoringHandler.js
+++ b/modules/monitoringHandler.js
@@ -87,16 +87,21 @@ broadcast(`✅ *Order Terekseskusi:* Pending order untuk ${pendingData.symbol} (
                     // KASUS 1: SUKSES! Detail penutupan ditemukan.
                     const profit = closingDeal.profit;
                     const reasonCode = closingDeal.reason;
-                    let closeReasonText = 'Ditutup Manual';
+                    let closeReasonText = 'Manual Close';
                     let notificationMessage = '';
 
-                    // Reason 5 = Take Profit, Reason 4 = Stop Loss (sesuaikan jika berbeda di broker Anda)
                     if (reasonCode === 5) {
                         closeReasonText = 'Take Profit Hit';
                         notificationMessage = `✅ *TP HIT:* Posisi ${positionData.symbol} (#${positionData.ticket}) mencapai Take Profit.\nProfit: ${profit.toFixed(2)}`;
                     } else if (reasonCode === 4) {
                         closeReasonText = 'Stop Loss Hit';
                         notificationMessage = `🛑 *SL HIT:* Posisi ${positionData.symbol} (#${positionData.ticket}) menyentuh Stop Loss.\nProfit: ${profit.toFixed(2)}`;
+                    } else if (reasonCode === 1) {
+                        closeReasonText = 'Closed by User';
+                        notificationMessage = `ℹ️ *DITUTUP MANUAL:* Posisi ${positionData.symbol} (#${positionData.ticket}) ditutup manual.\nProfit/Loss: ${profit.toFixed(2)}`;
+                    } else if (reasonCode === 3) {
+                        closeReasonText = 'Closed by Program';
+                        notificationMessage = `ℹ️ *DITUTUP PROGRAM:* Posisi ${positionData.symbol} (#${positionData.ticket}) ditutup oleh program lain.\nProfit/Loss: ${profit.toFixed(2)}`;
                     } else {
                         notificationMessage = `ℹ️ *POSISI DITUTUP:* Posisi ${positionData.symbol} (#${positionData.ticket}) telah ditutup.\nProfit/Loss: ${profit.toFixed(2)}`;
                     }


### PR DESCRIPTION
## Summary
- fix closing deal lookup by querying broker API with `position` parameter
- map additional broker reason codes in monitoring handler
- all tests pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ccfac967883229ed9d99f19bc2ce6