### PR TITLE
Add force analysis and manual news command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Bot menerima beberapa perintah teks. Berikut ringkasannya:
 - `/status` – Ringkasan status bot dan posisi saat ini.
 - `/dxy` – Analisis khusus indeks dolar.
 - `/<pair>` (misal `/usdjpy`) – Meminta analisis instan untuk pair tersebut.
+- `/<pair> force` – Memaksa analisis pair, melewati filter sesi dan hard filter.
+- `/news` – Mencari berita ekonomi berdampak tinggi secara manual.
 - `/cls <PAIR>` – Menutup posisi atau pending order yang sedang tercatat.
 - `/pause` dan `/resume` – Menjeda atau melanjutkan analisis otomatis terjadwal.
 - `/profit_today` – Menampilkan total profit/loss hari ini.

--- a/index.js
+++ b/index.js
@@ -178,6 +178,9 @@ async function main() { // PERBAIKAN: Kurung kurawal pembuka dipindahkan ke sini
                 case '/profit_today': // Perintah baru
                     await commandHandler.handleProfitTodayCommand(whatsappSocket, chatId);
                     break;
+                case '/news':
+                    await commandHandler.handleNewsCommand(whatsappSocket, chatId);
+                    break;
                 case '/dxy':
                     if (global.botSettings.recipients.length === 0) return;
                     await analysisHandler.analyzeDXY(whatsappSocket, global.botSettings.recipients);
@@ -187,12 +190,14 @@ async function main() { // PERBAIKAN: Kurung kurawal pembuka dipindahkan ke sini
                     await analysisHandler.runScheduledAnalysis(SUPPORTED_PAIRS, global.botSettings, whatsappSocket, global.botSettings.recipients);
                     break;
                 default:
-                    const requestedPair = command.substring(1).toUpperCase();
+                    const parts = text.split(' ');
+                    const requestedPair = parts[0].substring(1).toUpperCase();
+                    const force = parts[1] && parts[1].toLowerCase() === 'force';
                     if (SUPPORTED_PAIRS.includes(requestedPair)) {
                         if (global.botSettings.recipients.length === 0) return;
-                        await analysisHandler.handleAnalysisRequest(requestedPair, null, global.botSettings, whatsappSocket, global.botSettings.recipients);
+                        await analysisHandler.handleAnalysisRequest(requestedPair, null, global.botSettings, whatsappSocket, global.botSettings.recipients, force);
                     }
-                    break; 
+                    break;
             }
         } catch (error) {
             log.error(`Error saat memproses perintah "${text}":`, error);

--- a/modules/analysis/helpers.js
+++ b/modules/analysis/helpers.js
@@ -240,6 +240,7 @@ module.exports={
     writeJsonFile,
     getChartImages,
     broadcastMessage,
+    getEconomicNews,
     getDailyNews,
     getMarketContext,
     getCurrentMarketSession,

--- a/modules/commandHandler.js
+++ b/modules/commandHandler.js
@@ -13,6 +13,7 @@ const broker = require('./brokerHandler');
 const journalingHandler = require('./journalingHandler');
 // PERBAIKAN: Menambahkan impor yang hilang
 const analysisHandler = require('./analysisHandler');
+const { getEconomicNews } = require('./analysis/helpers');
 
 const PENDING_DIR = path.join(__dirname, '..', 'pending_orders');
 const POSITIONS_DIR = path.join(__dirname, '..', 'live_positions');
@@ -55,6 +56,8 @@ async function handleMenuCommand(whatsappSocket, chatId, supportedPairs = []) {
 *ANALISIS*
 ▫️ \`/dxy\` : Analisis DXY.
 ▫️ \`/${supportedPairs.join(', /').toLowerCase()}\` : Analisis Pair.
+▫️ \`/<pair> force\` : Analisis paksa pair (abaikan filter).
+▫️ \`/news\` : Cari berita ekonomi terbaru.
 
 *MANAJEMEN & LAPORAN*
 ▫️ \`/status\` : Status lengkap bot.
@@ -255,6 +258,12 @@ async function handleProfitTodayCommand(whatsappSocket, chatId) {
     }
 }
 
+async function handleNewsCommand(whatsappSocket, chatId) {
+    await whatsappSocket.sendMessage(chatId, { text: '⏳ Mencari berita ekonomi terbaru...' });
+    const news = await getEconomicNews();
+    await whatsappSocket.sendMessage(chatId, { text: `📰 *Berita Ekonomi:*\n\n${news}` });
+}
+
 module.exports = {
     handleMenuCommand,
     handleConsolidatedStatusCommand,
@@ -266,5 +275,6 @@ module.exports = {
     handleListRecipients,
     handlePauseCommand,
     handleResumeCommand,
-    handleProfitTodayCommand
+    handleProfitTodayCommand,
+    handleNewsCommand
 };


### PR DESCRIPTION
## Summary
- add ability to force pair analysis via `/pair force`
- add `/news` command to fetch current economic news
- export `getEconomicNews` and implement handler for news
- show new commands in menu and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687de4fce52c8322983b267bf40272ba