### PR TITLE
Add session/filter toggle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Bot menerima beberapa perintah teks. Berikut ringkasannya:
 - `/news` – Mencari berita ekonomi berdampak tinggi secara manual.
 - `/cls <PAIR>` – Menutup posisi atau pending order yang sedang tercatat.
 - `/pause` dan `/resume` – Menjeda atau melanjutkan analisis otomatis terjadwal.
+- `/sesi on|off` – Mengaktifkan atau menonaktifkan pengecekan sesi trading.
+- `/filter on|off` – Mengaktifkan atau menonaktifkan hard filter candle.
 - `/profit_today` – Menampilkan total profit/loss hari ini.
 - `/add_recipient <ID_WA>` dan `/del_recipient <ID_WA>` – Kelola daftar penerima notifikasi.
 - `/list_recipients` – Menampilkan daftar penerima.


### PR DESCRIPTION
## Summary
- add toggles for trading session and hard filter in bot settings
- persist toggle values in `bot_status.json`
- implement `/sesi` and `/filter` commands
- integrate settings into analysis logic
- document new commands in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687de71dc9588322a0a39fbd903a56b0