### PR TITLE
Fix journaling cleanup after failure

### DIFF
--- a/modules/journalingHandler.js
+++ b/modules/journalingHandler.js
@@ -107,10 +107,14 @@ async function recordTrade(closedTradeData, closeReason, finalBrokerData = {}) {
 
         await sheet.addRow(newRow);
         log.info(`[JOURNALING] Tiket #${ticket} berhasil dicatat ke Google Sheet.`);
-        await cleanupFiles(ticket, symbol);
 
     } catch (error) {
+        // Jika penulisan ke Google Sheets gagal kita tetap ingin
+        // membersihkan data lokal agar monitoring tidak berulang
         log.error(`[JOURNALING] Gagal total saat memproses jurnal untuk tiket #${ticket}:`, error);
+    } finally {
+        // Jalankan cleanup apapun hasilnya
+        await cleanupFiles(ticket, symbol);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure local files are always cleaned up in `recordTrade`
- this prevents repeated stop-loss alerts when journaling errors occur

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6880e80f87748322919f845bfa05058a