### PR TITLE
Fix closing deal selection bug

### DIFF
--- a/modules/brokerHandler.js
+++ b/modules/brokerHandler.js
@@ -166,7 +166,9 @@ async function getClosingDealInfo(positionId) {
           return null;
       }
 
-      const closingDeal = deals.find(deal => deal.entry === 1);
+      const closingDeal = deals
+          .filter(deal => deal.entry === 1 && deal.position_id === positionId)
+          .sort((a, b) => (b.time_msc || b.time || 0) - (a.time_msc || a.time || 0))[0];
 
       if (closingDeal) {
           log.info(`[BROKER HANDLER] SUKSES! Closing deal yang valid ditemukan untuk position ${positionId}:`, closingDeal);


### PR DESCRIPTION
## Summary
- ensure broker handler filters closing deals by position id and sorts them by latest time
- run existing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881bcbc10388322b2e2f26bcd79c75c